### PR TITLE
Finished custom methods for Enumerable module

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,49 @@
+AllCops:
+  Exclude:
+    - "Guardfile"
+    - "Rakefile"
+
+  DisplayCopNames: true
+
+Layout/LineLength:
+  Max: 120
+Metrics/MethodLength:
+  Max: 20
+Metrics/AbcSize:
+  Max: 50
+Metrics/ClassLength:
+  Max: 150
+Metrics/BlockLength:
+  ExcludedMethods: ["describe"]
+  Max: 30
+
+Style/Documentation:
+  Enabled: false
+Style/ClassAndModuleChildren:
+  Enabled: false
+Style/EachForSimpleLoop:
+  Enabled: false
+Style/AndOr:
+  Enabled: false
+Style/DefWithParentheses:
+  Enabled: false
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: never
+
+Layout/HashAlignment:
+  EnforcedColonStyle: key
+Layout/ExtraSpacing:
+  AllowForAlignment: false
+Layout/MultilineMethodCallIndentation:
+  Enabled: true
+  EnforcedStyle: indented
+Lint/RaiseException:
+  Enabled: false
+Lint/StructNewOverride:
+  Enabled: false
+Style/HashEachMethods:
+  Enabled: false
+Style/HashTransformKeys:
+  Enabled: false
+Style/HashTransformValues:
+  Enabled: false

--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,0 +1,15 @@
+# add the linters you want stickler to use for this project
+linters:
+  rubocop:
+    display_cop_names: true
+    # indicate where is the config file for stylelint
+    config: "./rubocop.yml"
+
+files:
+  ignore:
+    - "Guardfile"
+    - "Rakefile"
+    - "node_modules/**/*"
+# PLEASE DO NOT enable auto fixing options
+# if you need extra support from you linter - do it in your local env as described in README for this config
+# find full documentation here: https://stickler-ci.com/docs

--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-# Enumerable_Methods
+# Enumerable Methods
+
+> This a project create with Ruby for terminal.
+
+In this project we recreated Enumerable ruby methods to get a better of understanding of how they work, they are not just magic.
+We learn about blocks and procs and when to use yield and call.
+
+## Built With
+
+- Ruby 2.6.5
+
+## Authors
+
+👤 **Emanuel**
+
+- Github: [@emasdev](https://github.com/emasdev)
+
+👤 **Jasem**
+
+- Github: [@Jasem](https://github.com/JasemDuncan)
+
+## 🤝 Contributing
+
+Contributions, issues and feature requests are welcome!
+
+Feel free to check the [issues page](https://github.com/emasdev/Bubble-Sort/issues).
+
+## Show your support
+
+Give a ⭐️ if you like this project!
+
+## Acknowledgments
+
+- Hat tip to anyone whose code was used
+- Inspiration
+- etc
+
+## 📝 License
+
+This project is [MIT](lic.url) licensed.

--- a/main.rb
+++ b/main.rb
@@ -48,7 +48,7 @@ module Enumerable
       end
     else
       arr.my_each do |x|
-        is_all = false if x.nil?
+        is_all = false if !x
       end
     end
     is_all
@@ -67,7 +67,7 @@ module Enumerable
       end
     else
       arr.my_each do |x|
-        is_any = true unless x.nil?
+        is_any = true unless !x
       end
     end
     is_any
@@ -124,19 +124,35 @@ module Enumerable
   end
 
   def my_inject(*args)
-    return unless block_given?
-
     array = self
     array = to_a if is_a?(Range)
     start = args[0] if args[0].is_a?(Integer)
-    array.my_each do |num|
-      start = if start
-                yield(start, num)
-              else
-                num
-              end
+    is_symbol = args[0].is_a?(Symbol) || args[1].is_a?(Symbol)
+    if is_symbol
+      if args[1].is_a?(Symbol)
+        symbol = args[1]
+        start = args[0]  
+      else
+        symbol = args[0]
+      end
+      array.my_each do |num|
+        if start
+          start = eval(start.to_s + symbol.to_s + num.to_s)
+        else
+          start = num
+        end
+      end
+      return start
     end
-    start
+    
+    array.my_each do |num|
+      if start
+        start = yield(start, num)
+      else
+        start = num
+      end
+    end
+    return start
   end
 end
 # rubocop:enable Metrics/ModuleLength
@@ -144,3 +160,8 @@ end
 def multiply_els(arr)
   arr.my_inject { |a, b| a * b }
 end
+
+# Sum some numbers
+puts (5..10).my_inject(:+)                             #=> 45
+# Same using a block and inject
+# puts (5..10).my_inject(1) { |sum, n| sum + n }            #=> 45

--- a/main.rb
+++ b/main.rb
@@ -4,8 +4,11 @@ module Enumerable
   def my_each
     return enum_for unless block_given?
 
-    count = 0
     arr = self
+    if arr.is_a?(Range)
+      arr = self.to_a
+    end
+    count = 0
     while count < arr.size
       yield arr[count]
       count += 1
@@ -33,35 +36,111 @@ module Enumerable
     array_with_selection
   end
 
-  def my_all?
-    return unless block_given?
-
+  def my_all?(*args)
     arr = self
-    arr.my_each do |x|
-      return false unless yield(x)
-
-      return true
+    if(args[0])
+      arr.my_each do |x|
+        return false unless x == args[0]
+        return true
+      end
+    else
+      arr.my_each do |x|
+        return false unless yield(x)
+        return true
+      end
     end
   end
 
-  def my_any?
-    return unless block_given?
-
+  def my_any?(*args)
     arr = self
-    arr.my_each do |x|
-      return true unless yield(x)
-
-      return false
+    if(args[0])
+      arr.my_each do |x|
+        return true unless x == args[0]
+        return false
+      end
+    else
+      arr.my_each do |x|
+        return true unless yield(x)
+        return false
+      end
     end
   end
 
   def my_none?
-    return unless block_given?
-
-    !my_any?
+    !self.my_any?
   end
-end
 
+  def my_count(*args)
+    count = 0;
+    if(args[0])
+      self.my_each do |x| 
+        if x == args[0] 
+          count += 1
+        end 
+      end
+    elsif !block_given?
+      count = self.size
+    elsif(!args[0])
+      my_each do|x| 
+        if yield x 
+          count += 1
+        end
+      end
+    end
+    count
+  end
+
+  def my_map
+    return enum_for unless block_given?
+
+    array = []
+    self.my_each do |x|
+      array.push yield(x)
+    end
+    array 
+  end
+
+  def my_inject(*args)
+    array = self
+    if self.is_a?(Range)
+      array = self.to_a
+    end
+
+    if block_given?
+      start = args[0] if args[0].is_a?(Integer)
+      array.my_each do |num| 
+        if start = start
+          start = yield(start, num)
+        else
+          start = num
+        end 
+      end
+      return start
+    end
+  end
+
+
+  # def my_inject(*args)
+  #   list = is_a?(Range) ? to_a : self
+
+  #   reduce = args[0] if args[0].is_a?(Integer)
+  #   operator = args[0].is_a?(Symbol) ? args[0] : args[1]
+
+  #   if operator
+  #     list.my_each { |item| reduce = reduce ? reduce.send(operator, item) : item }
+  #     return reduce
+  #   end
+  #   list.my_each { |item| reduce = reduce ? yield(reduce, item) : item }
+  #   reduce
+  # end
+
+end
+puts "result"
+puts (5..10).my_inject(1){ |sum,num| sum + num}         #=> 45
+# puts (5..10).inject{ |sum,num| sum + num}         #=> 45
+# (5..10).my_each{ |x| puts x}         #=> 45
+# puts (5..10).my_inject(1) { |sum, n| sum + n } 
+# puts (5..10).my_inject { |product, n| product * n } #=> 151200
 # [1,2,3].my_each {|i| print "-#{i}- "}
 # [4,3,2].my_each_with_index {|i,index| puts "-index #{index} : #{i}- "}
 # print [1, 2, 3, 4, 5].my_all?(&:even?)

--- a/main.rb
+++ b/main.rb
@@ -40,8 +40,14 @@ module Enumerable
     is_all = true
     if !args[0].nil?
       arr.my_each do |x|
-        is_all = false unless args[0] == x
-      end
+        if args[0].is_a?(Class)
+          is_all = false unless x.is_a?(args[0])
+        elsif args[0].is_a?(Regexp)
+          is_all = false unless args[0].match?(x)
+        else
+          is_all = false unless args[0] == x
+        end
+      end 
     elsif block_given?
       arr.my_each do |x|
         is_all = false unless yield(x)
@@ -59,8 +65,14 @@ module Enumerable
     is_any = false
     if !args[0].nil?
       arr.my_each do |x|
-        is_any = true if args[0] == x
-      end
+        if args[0].is_a?(Class)
+          is_any = true if x.is_a?(args[0])
+        elsif args[0].is_a?(Regexp)
+          is_any = true if args[0].match?(x)
+        else
+          is_any = true if args[0] == x
+        end
+      end 
     elsif block_given?
       arr.my_each do |x|
         is_any = true if yield(x)
@@ -78,7 +90,13 @@ module Enumerable
     is_any = false
     if !args[0].nil?
       arr.my_each do |x|
-        is_any = true if args[0] == x
+        if args[0].is_a?(Class)
+          is_any = true if x.is_a?(args[0])
+        elsif args[0].is_a?(Regexp)
+          is_any = true if args[0].match?(x)
+        else
+          is_any = true if args[0] == x
+        end
       end
     elsif block_given?
       arr.my_each do |x|
@@ -160,8 +178,3 @@ end
 def multiply_els(arr)
   arr.my_inject { |a, b| a * b }
 end
-
-# Sum some numbers
-puts (5..10).my_inject(:+)                             #=> 45
-# Same using a block and inject
-# puts (5..10).my_inject(1) { |sum, n| sum + n }            #=> 45

--- a/main.rb
+++ b/main.rb
@@ -1,27 +1,68 @@
+# frozen_string_literal: true
+
 module Enumerable
   def my_each
     return enum_for unless block_given?
-    
+
     count = 0
     arr = self
     while count < arr.size
       yield arr[count]
-      count += 1      
+      count += 1
     end
-  end 
-  
+  end
+
   def my_each_with_index
     return enum_for unless block_given?
-    
+
     count = 0
     arr = self
     while count < arr.size
-      yield arr[count],count
-      count += 1      
+      yield arr[count], count
+      count += 1
     end
-  end 
+  end
+
+  def my_select
+    return enum_for unless block_given? # if !block_given? return enum_for
+
+    array_with_selection = []
+    my_each do |x|
+      array_with_selection.push(x) if yield(x)
+    end
+    array_with_selection
+  end
+
+  def my_all?
+    return unless block_given?
+
+    arr = self
+    arr.my_each do |x|
+      return false unless yield(x)
+
+      return true
+    end
+  end
+
+  def my_any?
+    return unless block_given?
+
+    arr = self
+    arr.my_each do |x|
+      return true unless yield(x)
+
+      return false
+    end
+  end
+
+  def my_none?
+    return unless block_given?
+
+    !my_any?
+  end
 end
 
 # [1,2,3].my_each {|i| print "-#{i}- "}
-[4,3,2].my_each_with_index {|i,index| puts "-index #{index} : #{i}- "}
-
+# [4,3,2].my_each_with_index {|i,index| puts "-index #{index} : #{i}- "}
+# print [1, 2, 3, 4, 5].my_all?(&:even?)
+# print [1, 3, 5, 9].my_any?(&:even?)

--- a/main.rb
+++ b/main.rb
@@ -119,25 +119,16 @@ module Enumerable
     end
   end
 
-
-  # def my_inject(*args)
-  #   list = is_a?(Range) ? to_a : self
-
-  #   reduce = args[0] if args[0].is_a?(Integer)
-  #   operator = args[0].is_a?(Symbol) ? args[0] : args[1]
-
-  #   if operator
-  #     list.my_each { |item| reduce = reduce ? reduce.send(operator, item) : item }
-  #     return reduce
-  #   end
-  #   list.my_each { |item| reduce = reduce ? yield(reduce, item) : item }
-  #   reduce
-  # end
-
 end
-puts "result"
-puts (5..10).my_inject(1){ |sum,num| sum + num}         #=> 45
-# puts (5..10).inject{ |sum,num| sum + num}         #=> 45
+
+def multiply_els(arr)
+   arr.my_inject {|a,b| a*b} 
+end
+
+time=Time.new
+puts time.min
+# puts (5..10).my_inject(1){ |sum,num| sum + num}         #=> 45
+# # puts (5..10).inject{ |sum,num| sum + num}         #=> 45
 # (5..10).my_each{ |x| puts x}         #=> 45
 # puts (5..10).my_inject(1) { |sum, n| sum + n } 
 # puts (5..10).my_inject { |product, n| product * n } #=> 151200

--- a/main.rb
+++ b/main.rb
@@ -40,7 +40,6 @@ module Enumerable
   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/PerceivedComplexity
 
-  
   def my_all?(*args)
     arr = self
     is_all = true
@@ -53,14 +52,14 @@ module Enumerable
         else
           is_all = false unless args[0] == x
         end
-      end 
+      end
     elsif block_given?
       arr.my_each do |x|
         is_all = false unless yield(x)
       end
     else
       arr.my_each do |x|
-        is_all = false if !x
+        is_all = false unless x
       end
     end
     is_all
@@ -71,21 +70,21 @@ module Enumerable
     is_any = false
     if !args[0].nil?
       arr.my_each do |x|
-        if args[0].is_a?(Class)
-          is_any = true if x.is_a?(args[0])
-        elsif args[0].is_a?(Regexp)
-          is_any = true if args[0].match?(x)
-        else
-          is_any = true if args[0] == x
+        if args[0].is_a?(Class) && x.is_a?(args[0])
+          is_any = true
+        elsif args[0].is_a?(Regexp) && args[0].match?(x)
+          is_any = true
+        elsif args[0] == x
+          is_any = true
         end
-      end 
+      end
     elsif block_given?
       arr.my_each do |x|
         is_any = true if yield(x)
       end
     else
       arr.my_each do |x|
-        is_any = true unless !x
+        is_any = true if x
       end
     end
     is_any
@@ -96,12 +95,12 @@ module Enumerable
     is_any = false
     if !args[0].nil?
       arr.my_each do |x|
-        if args[0].is_a?(Class)
-          is_any = true if x.is_a?(args[0])
-        elsif args[0].is_a?(Regexp)
-          is_any = true if args[0].match?(x)
-        else
-          is_any = true if args[0] == x
+        if args[0].is_a?(Class) && x.is_a?(args[0])
+          is_any = true
+        elsif args[0].is_a?(Regexp) && args[0].match?(x)
+          is_any = true
+        elsif args[0] == x
+          is_any = true
         end
       end
     elsif block_given?

--- a/main.rb
+++ b/main.rb
@@ -90,12 +90,15 @@ module Enumerable
     count
   end
 
-  def my_map
-    return enum_for unless block_given?
-
+  def my_map(my_proc = nil)
+    using_proc = !my_proc.nil?
     array = []
     self.my_each do |x|
-      array.push yield(x)
+      if using_proc
+        array.push my_proc.call(x)
+      else
+        array.push yield(x)
+      end
     end
     array 
   end
@@ -125,8 +128,15 @@ def multiply_els(arr)
    arr.my_inject {|a,b| a*b} 
 end
 
-time=Time.new
-puts time.min
+my_proc = Proc.new {  |i| i*i }
+# puts "without proc"
+# print (1..4).my_map {  |i| i*i }
+# puts ""
+# puts "============="
+# puts "with proc"
+# print (1..4).my_map(my_proc) { |i| i+i }
+# puts ""
+
 # puts (5..10).my_inject(1){ |sum,num| sum + num}         #=> 45
 # # puts (5..10).inject{ |sum,num| sum + num}         #=> 45
 # (5..10).my_each{ |x| puts x}         #=> 45

--- a/main.rb
+++ b/main.rb
@@ -4,26 +4,25 @@ module Enumerable
   def my_each
     return enum_for unless block_given?
 
-    arr = self
-    arr = to_a if arr.is_a?(Range)
+    arr = to_a
     count = 0
     while count < arr.size
       yield arr[count]
       count += 1
     end
-    arr
+    self
   end
 
   def my_each_with_index
     return enum_for unless block_given?
 
     count = 0
-    arr = self
+    arr = to_a
     while count < arr.size
       yield arr[count], count
       count += 1
     end
-    arr
+    self
   end
 
   def my_select

--- a/main.rb
+++ b/main.rb
@@ -1,13 +1,9 @@
-# frozen_string_literal: true
-
 module Enumerable
   def my_each
     return enum_for unless block_given?
 
     arr = self
-    if arr.is_a?(Range)
-      arr = self.to_a
-    end
+    arr = to_a if arr.is_a?(Range)
     count = 0
     while count < arr.size
       yield arr[count]
@@ -38,14 +34,16 @@ module Enumerable
 
   def my_all?(*args)
     arr = self
-    if(args[0])
+    if args[0]
       arr.my_each do |x|
         return false unless x == args[0]
+
         return true
       end
     else
       arr.my_each do |x|
         return false unless yield(x)
+
         return true
       end
     end
@@ -53,38 +51,36 @@ module Enumerable
 
   def my_any?(*args)
     arr = self
-    if(args[0])
+    if args[0]
       arr.my_each do |x|
         return true unless x == args[0]
+
         return false
       end
     else
       arr.my_each do |x|
         return true unless yield(x)
+
         return false
       end
     end
   end
 
   def my_none?
-    !self.my_any?
+    !my_any?
   end
 
   def my_count(*args)
-    count = 0;
-    if(args[0])
-      self.my_each do |x| 
-        if x == args[0] 
-          count += 1
-        end 
+    count = 0
+    if args[0]
+      my_each do |x|
+        count += 1 if x == args[0]
       end
     elsif !block_given?
-      count = self.size
-    elsif(!args[0])
-      my_each do|x| 
-        if yield x 
-          count += 1
-        end
+      count = size
+    elsif !args[0]
+      my_each do |x|
+        count += 1 if yield x
       end
     end
     count
@@ -93,56 +89,34 @@ module Enumerable
   def my_map(my_proc = nil)
     using_proc = !my_proc.nil?
     array = []
-    self.my_each do |x|
+    my_each do |x|
       if using_proc
         array.push my_proc.call(x)
       else
         array.push yield(x)
       end
     end
-    array 
+    array
   end
 
   def my_inject(*args)
-    array = self
-    if self.is_a?(Range)
-      array = self.to_a
-    end
+    return unless block_given?
 
-    if block_given?
-      start = args[0] if args[0].is_a?(Integer)
-      array.my_each do |num| 
-        if start = start
-          start = yield(start, num)
-        else
-          start = num
-        end 
+    array = self
+    array = to_a if is_a?(Range)
+
+    start = args[0] if args[0].is_a?(Integer)
+    array.my_each do |num|
+      if (start = start)
+        yield(start, num)
+      else
+        num
       end
-      return start
+      start
     end
   end
-
 end
 
 def multiply_els(arr)
-   arr.my_inject {|a,b| a*b} 
+  arr.my_inject { |a, b| a * b }
 end
-
-my_proc = Proc.new {  |i| i*i }
-# puts "without proc"
-# print (1..4).my_map {  |i| i*i }
-# puts ""
-# puts "============="
-# puts "with proc"
-# print (1..4).my_map(my_proc) { |i| i+i }
-# puts ""
-
-# puts (5..10).my_inject(1){ |sum,num| sum + num}         #=> 45
-# # puts (5..10).inject{ |sum,num| sum + num}         #=> 45
-# (5..10).my_each{ |x| puts x}         #=> 45
-# puts (5..10).my_inject(1) { |sum, n| sum + n } 
-# puts (5..10).my_inject { |product, n| product * n } #=> 151200
-# [1,2,3].my_each {|i| print "-#{i}- "}
-# [4,3,2].my_each_with_index {|i,index| puts "-index #{index} : #{i}- "}
-# print [1, 2, 3, 4, 5].my_all?(&:even?)
-# print [1, 3, 5, 9].my_any?(&:even?)

--- a/main.rb
+++ b/main.rb
@@ -1,4 +1,5 @@
 # rubocop:disable Metrics/ModuleLength
+
 module Enumerable
   def my_each
     return enum_for unless block_given?
@@ -35,6 +36,11 @@ module Enumerable
     array_with_selection
   end
 
+  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
+
+  
   def my_all?(*args)
     arr = self
     is_all = true
@@ -110,6 +116,9 @@ module Enumerable
     !is_any
   end
 
+  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/PerceivedComplexity
   def my_count(*args)
     count = 0
     if args[0]
@@ -141,6 +150,10 @@ module Enumerable
     array
   end
 
+  # rubocop:disable Security/Eval
+  # rubocop:disable Style/ConditionalAssignment
+  # rubocop:disable Metrics/PerceivedComplexity
+  # rubocop:disable Metrics/CyclomaticComplexity:
   def my_inject(*args)
     array = self
     array = to_a if is_a?(Range)
@@ -149,29 +162,24 @@ module Enumerable
     if is_symbol
       if args[1].is_a?(Symbol)
         symbol = args[1]
-        start = args[0]  
+        start = args[0]
       else
         symbol = args[0]
       end
       array.my_each do |num|
-        if start
-          start = eval(start.to_s + symbol.to_s + num.to_s)
-        else
-          start = num
-        end
+        start ? start = eval(start.to_s + symbol.to_s + num.to_s) : start = num
       end
       return start
     end
-    
     array.my_each do |num|
-      if start
-        start = yield(start, num)
-      else
-        start = num
-      end
+      start ? start = yield(start, num) : start = num
     end
-    return start
+    start
   end
+  # rubocop:enable Security/Eval
+  # rubocop:enable Style/ConditionalAssignment
+  # rubocop:enable Metrics/PerceivedComplexity
+  # rubocop:enable Metrics/CyclomaticComplexity:
 end
 # rubocop:enable Metrics/ModuleLength
 

--- a/main.rb
+++ b/main.rb
@@ -1,0 +1,27 @@
+module Enumerable
+  def my_each
+    return enum_for unless block_given?
+    
+    count = 0
+    arr = self
+    while count < arr.size
+      yield arr[count]
+      count += 1      
+    end
+  end 
+  
+  def my_each_with_index
+    return enum_for unless block_given?
+    
+    count = 0
+    arr = self
+    while count < arr.size
+      yield arr[count],count
+      count += 1      
+    end
+  end 
+end
+
+# [1,2,3].my_each {|i| print "-#{i}- "}
+[4,3,2].my_each_with_index {|i,index| puts "-index #{index} : #{i}- "}
+


### PR DESCRIPTION
In this project, we add custom methods for the Enumerable module

-Create a script file to house your methods and run it in IRB to test them later.
Add your new methods onto the existing Enumerable module. Ruby makes this easy for you because any class or module can be added to without trouble ... just do something like:
  module Enumerable
    def my_each
      # your code here
    end
  end
-Create #my_each, a method that is identical to #each but (obviously) does not use #each. You'll need to remember the yield statement. Make sure it returns the same thing as #each as well.
-Create #my_each_with_index in the same way.
-Create #my_select in the same way, though you may use #my_each in your definition (but not #each).
-Create #my_all? (continue as above)
-Create #my_any?
-Create #my_none?
-Create #my_count
-Create #my_map
-Create #my_inject
-Test your #my_inject by creating a method called #multiply_els which multiplies all the elements of the array together by using #my_inject, e.g. multiply_els([2,4,5]) #=> 40
-Modify your #my_map method to take a proc instead.
-Modify your #my_map method to take either a proc or a block. It won't be necessary to apply both a proc and a block in the same #my_map call since you could get the same effect by chaining together one #my_map call with the block and one with the proc. This approach is also clearer, since the user doesn't have to remember whether the proc or block will be run first. So if both a proc and a block are given, only execute the proc.